### PR TITLE
Updated .travis.yml to support ruby-3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.2
   - 2.3.0
   - 2.4.0
+  - 2.5.0
+  - 2.6.0
+  - 2.7.0
+  - 3.0.0
   #- jruby
 before_install:
  - gem update bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 PR authors, please add entries here.
 
+- PR#200 removed ruby 2.2.2 from `.travis.yml`
+- PR#200 added rubies 2.5.0, 2.6.0, 2.7.0, 3.0.0 to `.travis.yml`
+- PR#200 added sorted_set gem to dependencies list
+
 ## 0.9.3 2017-11-04
 - PR#165 - fixes an issue with 0.business_<x> calculations
 - PR#166 - added est for business_days.before edge case


### PR DESCRIPTION
- removed ruby 2.2.2
- added rubies 2.5.0, 2.6.0, 2.7.0, 3.0.0